### PR TITLE
Pin torchcodec<0.11 (torch 2.10 ABI mismatch)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ pygit2
 omegaconf
 audiostretchy
 torch-time-stretch
-torchcodec
+torchcodec>=0.10,<0.11


### PR DESCRIPTION
## Problem

`torchcodec 0.11.x` wheels reference the symbol `_torch_dtype_float4_e2m1fn_x2` (FP4-E2M1 dtype) in every per-FFmpeg-major dylib. That symbol is absent in `torch 2.10.x` — FP4 dtype landed upstream after 2.10. Result: ComfyUI-F5-TTS fails to import on any system running torch 2.10 + torchcodec 0.11 (the current pip default).

## Symptom

Users see a misleading "Could not load libtorchcodec" error pointing at the FFmpeg fallback chain:

```
RuntimeError: Could not load libtorchcodec. Likely causes:
          1. FFmpeg is not properly installed in your environment...
[start of libtorchcodec loading traceback]
FFmpeg version 8:
OSError: dlopen(.../libtorchcodec_core8.dylib): Symbol not found:
  _torch_dtype_float4_e2m1fn_x2
  Expected in: .../torch/lib/libtorch_cpu.dylib
```

The wrapping `RuntimeError` text frames it as an FFmpeg ABI issue, but the **first** per-FFmpeg-major sub-traceback shows the real cause: a torch ABI mismatch. Installing `ffmpeg@7` with a `DYLD_LIBRARY_PATH` shim doesn't help — every dylib in the wheel (`core4` through `core8`) has the same FP4 dependency. I burned ~10 minutes chasing the FFmpeg framing before reading the full trace; surfacing this in the requirements pin saves others the same trip.

## Fix

Pin `torchcodec>=0.10,<0.11`:
- `0.10.x` has the audio APIs F5-TTS uses (`AudioDecoder`, `AudioEncoder`)
- Lower bound encodes the dependency on `0.10`'s audio surface
- Constraint can be relaxed to `<0.12` once `torch 2.11` becomes the floor for ComfyUI

## Verification

- `torch 2.10.0` + `torchcodec 0.10.0` on Mac M4 Max (MPS): ComfyUI-F5-TTS imports cleanly and produces valid 24kHz mono FLAC.
- Verified per-dylib symbol presence with `otool -L`/`nm -gU` against `libtorch_cpu.dylib` to confirm FP4 is genuinely absent in torch 2.10's lib.

## References

- torchcodec compatibility table: https://github.com/pytorch/torchcodec#installing-torchcodec
- PyTorch FP4 dtype (`Float4_e2m1fn_x2` ScalarType) landed post-2.10